### PR TITLE
Adding support for multiple time series

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -309,20 +309,22 @@ export class SumologicDatasource {
       return {target: metricLabel, datapoints: dps};
     }
 
+    records =records.sort((a, b) => {
+      if (keyField === '') {
+        return 0;
+      }
+      if (a.map[keyField] < b.map[keyField]) {
+        return -1;
+      } else if (a.map[keyField] > b.map[keyField]) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
+
     valueFields.forEach((valueField) => {
       let result = {};
-      records.sort((a, b) => {
-        if (keyField === '') {
-          return 0;
-        }
-        if (a.map[keyField] < b.map[keyField]) {
-          return -1;
-        } else if (a.map[keyField] > b.map[keyField]) {
-          return 1;
-        } else {
-          return 0;
-        }
-      }).forEach((r) => {
+      records.forEach((r) => {
         metricLabel = this.createMetricLabel(r.map, target);
         result[metricLabel] = result[metricLabel] || [];
         let timestamp = parseFloat(r.map[keyField] || defaultValue);


### PR DESCRIPTION
The problem was there can be multiple value fields in response for eg:
`
{
	"fields": [{
		"name": "_timeslice",
		"fieldType": "long",
		"keyField": true
	}, {
		"name": "com.sumologic.cocoa.BadEventRequestException",
		"fieldType": "int",
		"keyField": false
	}, {
		"name": "java.net.SocketTimeoutException",
		"fieldType": "int",
		"keyField": false
	}],
	"records": [{
		"map": {
			"_timeslice": "1532701200000",
			"java.net.SocketTimeoutException": "11",
			"com.sumologic.cocoa.BadEventRequestException": "6"
		}
	}, {
		"map": {
			"_timeslice": "1532701800000",
			"java.net.SocketTimeoutException": "1",
			"com.sumologic.cocoa.BadEventRequestException": "12"
		}
	}, {
		"map": {
			"_timeslice": "1532702400000",
			"java.net.SocketTimeoutException": "",
			"com.sumologic.cocoa.BadEventRequestException": "35"
		}
	}, {
		"map": {
			"_timeslice": "1532703000000",
			"java.net.SocketTimeoutException": "19",
			"com.sumologic.cocoa.BadEventRequestException": "10"
		}
	}]
}
`