### PR TITLE
Prevent stripComment() function from interfering with geo:// lookup syntax

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -471,7 +471,7 @@ export default class SumologicDatasource extends DataSourceApi<SumologicQuery, S
     return query
       .split('\n')
       .map(q => {
-        return q.replace(/(\/\*([\s\S]*?)\*\/)|(\/\/(.*)$)/gm, '');
+        return q.replace(/(\/\*([\s\S]*?)\*\/)/gm, '').replace(/([^:])(\/\/(.*)$)/gm, '$1');
       })
       .filter(q => {
         return q !== '';

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -23,8 +23,8 @@
     ],
     "screenshots": [
     ],
-    "version": "1.0.10",
-    "updated": "2020-01-22"
+    "version": "1.0.11",
+    "updated": "2020-04-17"
   },
 
   "dependencies": {


### PR DESCRIPTION
Sumologic has a `lookup` operator in its query language, which is, beyond other uses, is able to join records on geospatial data.

https://help.sumologic.com/05Search/Search-Query-Language/Search-Operators/Geo-Lookup

Unfortunately its syntax ( `lookup ... from geo://location` ) was interfering with `stripComment()` function of this plugin, which tainted all the query with geospatial data usage.

This patch fixes the `stripComment()` regexp, so now `://` is not treated as comment 